### PR TITLE
[WIP] PHP 8.0 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,3 +36,33 @@ jobs:
 
     - name: Run test suite
       run: composer run-script test
+
+  build_php_80:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup PHP with PECL extension
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.0'
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": ">=7.3",
         "bitpay/sdk": "~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
- [ ] Wait for upstream Bitpay library to support the PHP 8.0 https://github.com/bitpay/php-bitpay-client-v2/issues/57
- [ ] Add PHP 8.0 support
- [ ] Add action to build and test on PHP 8.0
- [ ] build_php_80 build action should pass once PHP 8.0 support is added