### PR TITLE
Fix error while pairing with server

### DIFF
--- a/src/Commands/CreateKeypair.php
+++ b/src/Commands/CreateKeypair.php
@@ -153,8 +153,8 @@ class CreateKeypair extends Command
             $response = $bitpayClient->post('/tokens', [
                 'json'    => $postData,
                 'headers' => [
-                    'x-accept-version: 2.0.0',
-                    'Content-Type: application/json',
+                    'x-accept-version' => '2.0.0',
+                    'Content-Type' => 'application/json',
                     // Todo: If added below headers, bitpay responds with error, "This endpoint does not support the `user` facade"
                     // 'x-identity' => $this->publicKey->__toString(),
                     // 'x-signature' => $this->privateKey->sign($this->network.'/tokens'.json_encode($postData)),


### PR DESCRIPTION
This PR fixes a TypeError thrown by GuzzleHttp due to a malformed 'headers' array supplied in the pairing request to BitPay's server.

Issue can be reproduced by executing the **createkeypair** artisan command: `php artisan laravel-bitpay:createkeypair`