### PR TITLE
Added additional environment variable for the bitpay token label and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ php artisan vendor:publish --provider="Vrajroham\LaravelBitpay\LaravelBitpayServ
 #### Add configuration values
 Add following keys to `.env` file and updated the details ([view more about configuration](https://support.bitpay.com/hc/en-us/articles/115003001063-How-do-I-configure-the-PHP-BitPay-Client-Library-)):
 
+note: BITPAY_TOKEN_LABEL can be any name, but can not have spaces
+
 ```dotenv
 BITPAY_PRIVATE_KEY_PATH=/tmp/bitpay.pri
 BITPAY_PUBLIC_KEY_PATH=/tmp/bitpay.pub
 BITPAY_NETWORK=testnet
 BITPAY_KEY_STORAGE_PASSWORD=SomeRandomePasswordForKeypairEncryption
 BITPAY_TOKEN=
+BITPAY_TOKEN_LABEL=projectname
 ``` 
 
 #### Add webhook event listener

--- a/config/laravel-bitpay.php
+++ b/config/laravel-bitpay.php
@@ -37,4 +37,9 @@ return [
      * BitPay Token
      */
     'token' => env('BITPAY_TOKEN', ''),
+
+    /*
+     * BitPay Token label
+     */
+    'label' => env('BITPAY_TOKEN_LABEL', 'projectlabel'),
 ];

--- a/src/Commands/CreateKeypair.php
+++ b/src/Commands/CreateKeypair.php
@@ -144,7 +144,7 @@ class CreateKeypair extends Command
         $this->info(' - Connecting Bitpay server 🖥️  and generating token & pairing code.');
 
         try {
-            $this->pairingCodeLabel = config('app.name').'_BitPay_Client';
+            $this->pairingCodeLabel = config('laravel-bitpay.label').'_BitPay_Client';
             $postData = [
                 'id'     => (string) $this->sin,
                 'label'  => $this->pairingCodeLabel,


### PR DESCRIPTION
…added it to the config file, then replaced the app napp name out with this variable. The createkeypair command fails when the app name has spaces in it. Made a note in the readme also

Related to issue #32 